### PR TITLE
[MAIN] docs(route): Handle unmatched parallel route

### DIFF
--- a/src/app/dashboard/@notifications/archived/page.tsx
+++ b/src/app/dashboard/@notifications/archived/page.tsx
@@ -1,0 +1,15 @@
+import { NextPage } from "next";
+import Link from "next/link";
+
+interface Props {}
+
+const ArchivedNotification: NextPage<Props> = ({}) => {
+  return (
+    <div className="bg-yellow-600 p-4">
+      <h1>Archived Notifications</h1>
+      <Link href="/dashboard">Back to dashboard</Link>
+    </div>
+  );
+};
+
+export default ArchivedNotification;

--- a/src/app/dashboard/@notifications/page.tsx
+++ b/src/app/dashboard/@notifications/page.tsx
@@ -1,4 +1,5 @@
 import { NextPage } from "next";
+import Link from "next/link";
 
 interface Props {}
 
@@ -6,6 +7,8 @@ const Notification: NextPage<Props> = ({}) => {
   return (
     <div className="p-4 bg-yellow-500">
       <h1>Notification parallel route</h1>
+      {/* this route will cause error because @users now is unrouted */}
+      <Link href="/dashboard/archived">archived</Link>
     </div>
   );
 };

--- a/src/app/dashboard/@users/default.tsx
+++ b/src/app/dashboard/@users/default.tsx
@@ -1,0 +1,17 @@
+import { NextPage } from "next";
+
+interface Props {}
+
+const DefaultUserAnalyticPage: NextPage<Props> = ({}) => {
+  return (
+    <div className="bg-red-800 p-4">
+      <p>
+        This is default page when page is rendered when using parallel route
+        that have unmatched route
+      </p>
+      <h1>Default page for user analytics</h1>
+    </div>
+  );
+};
+
+export default DefaultUserAnalyticPage;

--- a/src/app/dashboard/default.tsx
+++ b/src/app/dashboard/default.tsx
@@ -1,0 +1,16 @@
+import { NextPage } from "next";
+
+interface Props {}
+
+const DefaultDashboardPage: NextPage<Props> = ({}) => {
+  return (
+    <div className="bg-cyan-800 p-4">
+      <h1>
+        This is default page when page is rendered when using parallel route
+        that have unmatched route
+      </h1>
+    </div>
+  );
+};
+
+export default DefaultDashboardPage;


### PR DESCRIPTION
## CHANGES
- docs(route): Handle example of using parallel route when a page that have unmatched route